### PR TITLE
Allow formatting of attributes

### DIFF
--- a/lib/src/bundle.dart
+++ b/lib/src/bundle.dart
@@ -40,12 +40,15 @@ class FluentBundle {
   }
 
   String format(String id,
-      {Map<String, dynamic> args = const {}, List<Error> errors}) {
+      {Map<String, dynamic> args = const {}, List<Error> errors, String attribute}) {
     Message message = this.messages[id];
     if (message == null) {
       return null;
     }
-    Pattern pattern = message.value;
+    Pattern pattern = attribute == null ? message.value : message.attributes[attribute];
+    if (pattern == null) {
+      return null;
+    }
     // Resolve a simple pattern without creating a scope. No error handling is
     // required; by definition simple patterns don't have placeables.
     if (pattern.elements.length == 1) {

--- a/test/fluent_test.dart
+++ b/test/fluent_test.dart
@@ -70,6 +70,16 @@ at the beginning of the third line:
 		expect(translated, '''To add an attribute to this messages, write
 .attr = Value on a new line.''');
 	});
+	test('use-attribute', () {
+		FluentBundle bundle = FluentBundle("en-GB");
+		bundle.addMessages('''attribute-how-to =
+    To add an attribute to this messages, write
+    {".attr = Value"} on a new line.
+    .attr = An actual attribute (not part of the text value above)
+''');
+		String translated = bundle.format("attribute-how-to", attribute: "attr");
+		expect(translated, '''An actual attribute (not part of the text value above)''');
+	});
 	test('literal-quote1', () {
 		FluentBundle bundle = FluentBundle("en-GB");
 		bundle.addMessages('''# This is OK, but cryptic and hard to read and edit.


### PR DESCRIPTION
Add a parameter to `FluentBundle.format` to allow selecting an attribute to format.