### PR TITLE
Use locale of bundle by default for NUMBER and DATETIME

### DIFF
--- a/lib/src/builtin.dart
+++ b/lib/src/builtin.dart
@@ -1,64 +1,67 @@
 import 'types.dart';
+import 'bundle.dart';
 
-FluentValue NUMBER(
-  num number, {
-  String? locale,
-  String? style,
-  String? currency,
-  // String? currencyDisplay,
-  bool? useGrouping,
-  int? minimumIntegerDigits,
-  int? minimumFractionDigits,
-  int? maximumFractionDigits,
-  // int? minimumSignificantDigits,
-  // int? maximumSignificantDigits,
-}) {
-  return FluentNumber(
-    number,
-    locale: locale,
-    style: style,
-    currency: currency,
-    useGrouping: useGrouping,
-    minimumIntegerDigits: minimumIntegerDigits,
-    minimumFractionDigits: minimumFractionDigits,
-    maximumFractionDigits: maximumFractionDigits,
-  );
-}
+extension Builtin on FluentBundle {
+  FluentValue NUMBER(
+    num number, {
+    String? locale,
+    String? style,
+    String? currency,
+    // String? currencyDisplay,
+    bool? useGrouping,
+    int? minimumIntegerDigits,
+    int? minimumFractionDigits,
+    int? maximumFractionDigits,
+    // int? minimumSignificantDigits,
+    // int? maximumSignificantDigits,
+  }) {
+    return FluentNumber(
+      number,
+      locale: locale ?? this.locale,
+      style: style,
+      currency: currency,
+      useGrouping: useGrouping,
+      minimumIntegerDigits: minimumIntegerDigits,
+      minimumFractionDigits: minimumFractionDigits,
+      maximumFractionDigits: maximumFractionDigits,
+    );
+  }
 
-FluentValue DATETIME(
-  DateTime datetime, {
-  String? locale,
-  String? pattern,
-  String? calendar,
-  String? numberingSystem,
-  String? timeZone,
-  bool? hour12,
-  String? weekday,
-  String? era,
-  String? year,
-  String? month,
-  String? day,
-  String? hour,
-  String? minute,
-  String? second,
-  String? timeZoneName,
-}) {
-  return FluentDateTime(
-    datetime,
-    locale: locale,
-    pattern: pattern,
-    calendar: calendar,
-    numberingSystem: numberingSystem,
-    timeZone: timeZone,
-    hour12: hour12,
-    weekday: weekday,
-    era: era,
-    year: year,
-    month: month,
-    day: day,
-    hour: hour,
-    minute: minute,
-    second: second,
-    timeZoneName: timeZoneName,
-  );
+  FluentValue DATETIME(
+    DateTime datetime, {
+    String? locale,
+    String? pattern,
+    String? calendar,
+    String? numberingSystem,
+    String? timeZone,
+    bool? hour12,
+    String? weekday,
+    String? era,
+    String? year,
+    String? month,
+    String? day,
+    String? hour,
+    String? minute,
+    String? second,
+    String? timeZoneName,
+  }) {
+    return FluentDateTime(
+      datetime,
+      locale: locale ?? this.locale,
+      pattern: pattern,
+      calendar: calendar,
+      numberingSystem: numberingSystem,
+      timeZone: timeZone,
+      hour12: hour12,
+      weekday: weekday,
+      era: era,
+      year: year,
+      month: month,
+      day: day,
+      hour: hour,
+      minute: minute,
+      second: second,
+      timeZoneName: timeZoneName,
+    );
+  }
 }

--- a/lib/src/bundle.dart
+++ b/lib/src/bundle.dart
@@ -18,10 +18,10 @@ class FluentBundle {
   final TextTransform transform;
 
   final Map<String, Message> messages = {};
-  final Map<String, Function> functions = {
-    'NUMBER': NUMBER,
-    'DATETIME': DATETIME,
-  };
+  Map<String, Function> get functions => {
+        'NUMBER': NUMBER,
+        'DATETIME': DATETIME,
+      };
 
   FluentBundle(this.locale,
       {this.useIsolating = false, this.transform = identity});


### PR DESCRIPTION
Without this change the default locale when using `DATETIME` and `NUMBER` is based on the default of `intl`, which may not match what is given to the bundle